### PR TITLE
Rename project from image-url-checker to url-examiner

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -3,8 +3,8 @@
 ### Installation
 
 ```bash
-git clone https://github.com/jbuget/image-url-checker.git
-cd image-url-checker
+git clone https://github.com/jbuget/url-examiner.git
+cd url-examiner
 npm install
 npm test
 ```

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# image-url-checker
+# url-examiner
 
 A small Node.js tool & library that checks image URL from a given CSV input file and report the analysis results in a new CSV output file. 
 
@@ -14,10 +14,10 @@ You need a working version of:
 
 ```bash
 # Basic
-npx image-url-checker -i input_file.csv -o output_file.csv
+npx url-examiner -i input_file.csv -o output_file.csv
 
 # Advanced (fullname)
-npx image-url-checker \ 
+npx url-examiner \ 
   --input input_file.csv \ 
   --output output_file.csv \
   --timeout 5000 \
@@ -28,7 +28,7 @@ npx image-url-checker \
   --bulk 50
 
 # Advanced (shortcut)
-npx image-url-checker \ 
+npx url-examiner \ 
   -i input_file.csv \ 
   -o output_file.csv \
   -m 5000 \
@@ -64,12 +64,12 @@ Supported data format (without head line):
 
 **Output file:**
 
-![Screenshot](docs/image-url-checker_screenshot.png)
+![Screenshot](docs/url-examiner_screenshot.png)
 
 ### As a library
 
 ```bash
-npm install image-url-checker
+npm install url-examiner
 ```
 
 ```javascript

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "image-url-checker",
+  "name": "url-examiner",
   "version": "0.8.0",
   "lockfileVersion": 1,
   "requires": true,

--- a/package.json
+++ b/package.json
@@ -1,15 +1,15 @@
 {
-  "name": "image-url-checker",
+  "name": "url-examiner",
   "version": "0.8.0",
   "description": "Node images URL checker",
   "main": "index.js",
   "bin": {
-    "image-url-checker": "./dist/index.js"
+    "url-examiner": "./dist/index.js"
   },
   "scripts": {
     "prebuild": "node -p \"'export const LIB_VERSION = ' + JSON.stringify(require('./package.json').version) + ';'\" > lib/version.ts",
     "build": "tsc",
-    "dist": "rm -rf dist && npm run build && cp -R build dist && pkg . --output dist/image-url-checker",
+    "dist": "rm -rf dist && npm run build && cp -R build dist && pkg . --output dist/url-examiner",
     "format": "prettier --config .prettierrc --write 'lib/**/*.ts'",
     "preversion": "./scripts/preversion.sh && npm run build && npm test",
     "version": "npm run dist && git add -A dist lib/version.ts",
@@ -28,14 +28,14 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jbuget/image-url-checker.git"
+    "url": "git+https://github.com/jbuget/url-examiner.git"
   },
   "author": "Jérémy Buget <contact@jbuget.fr>",
   "license": "AGPL-3.0",
   "bugs": {
-    "url": "https://github.com/jbuget/image-url-checker/issues"
+    "url": "https://github.com/jbuget/url-examiner/issues"
   },
-  "homepage": "https://github.com/jbuget/image-url-checker#readme",
+  "homepage": "https://github.com/jbuget/url-examiner#readme",
   "engines": {
     "node": "14.18.0",
     "npm": "6.14.15"


### PR DESCRIPTION
### Context

The project can now do more than simply check image URL. Thus the name is no more relevant.

### Engineering

Rename the project from `image-url-checker` to `url-examiner`.
